### PR TITLE
fix: correcting tuple bracket type

### DIFF
--- a/src/GeneticAlgorithm.py
+++ b/src/GeneticAlgorithm.py
@@ -292,7 +292,7 @@ class GeneticAlgorithm:
         ):
             self.schedules[i] = self.new_schedules[i]
 
-    def evolve(self) -> Tuple(bool, object, float, int, list):
+    def evolve(self) -> Tuple[bool, object, float, int, list]:
         """
         Function to execute the genetic algorithm until convergence or no change found
 

--- a/src/Schedule.py
+++ b/src/Schedule.py
@@ -674,7 +674,7 @@ class Schedule:
         schedule_df.to_csv(full_save_path)
         return schedule_df
 
-    def schedule_quality_check(self) -> Tuple(int, int, int, int):
+    def schedule_quality_check(self) -> Tuple[int, int, int, int]:
         """
         Function to do some basic checks to make sure all rules have worked as desired
 


### PR DESCRIPTION
PR to correct parentheses to square brackets when using tuple for type hints